### PR TITLE
Fix std@0.50.0 references

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,6 +1,6 @@
-export { parse } from "https://deno.land/std/flags/mod.ts";
-export { readZip } from "https://deno.land/x/jszip/mod.ts";
-export { ensureDir } from "https://deno.land/std/fs/ensure_dir.ts";
-export { move } from "https://deno.land/std/fs/move.ts";
-export { walk } from "https://deno.land/std/fs/walk.ts";
-export { Application, Router, Context as OakContext, Body } from "https://deno.land/x/oak/mod.ts";
+export { parse } from "https://deno.land/std@0.51.0/flags/mod.ts";
+export { readZip } from "https://raw.githubusercontent.com/anthonychu/deno-zip/std-v0.51.0/mod.ts";
+export { ensureDir } from "https://deno.land/std@0.51.0/fs/ensure_dir.ts";
+export { move } from "https://deno.land/std@0.51.0/fs/move.ts";
+export { walk } from "https://deno.land/std@0.51.0/fs/walk.ts";
+export { Application, Router, Context as OakContext, Body } from "https://deno.land/x/oak@v4.0.0/mod.ts";


### PR DESCRIPTION
Fix compile errors in Deno 1.0.0 caused by https://github.com/denoland/deno/issues/5319.

Temporarily pinning JSZip to a patched version on my fork.

Fixes #2.