### PR TITLE
Split worker and denofunc dependencies

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -3,4 +3,4 @@ export { readZip } from "https://raw.githubusercontent.com/anthonychu/deno-zip/s
 export { ensureDir } from "https://deno.land/std@0.53.0/fs/ensure_dir.ts";
 export { move } from "https://deno.land/std@0.53.0/fs/move.ts";
 export { walk } from "https://deno.land/std@0.53.0/fs/walk.ts";
-export { Application, Router, Context as OakContext, Body } from "https://deno.land/x/oak@v4.0.0/mod.ts";
+export * from "./worker_deps.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,4 @@
-import { Application, Router, OakContext, Body } from "./deps.ts";
+import { Application, Router, OakContext, Body } from "./worker_deps.ts";
 import { AzureFunction, Context, Logger, HttpRequest, HttpMethod } from "./types.ts"
 
 export interface FunctionRegistration {

--- a/worker_deps.ts
+++ b/worker_deps.ts
@@ -1,0 +1,1 @@
+export { Application, Router, Context as OakContext, Body } from "https://deno.land/x/oak@v4.0.0/mod.ts";


### PR DESCRIPTION
Split dependencies so that the deployed worker doesn't inadvertently reference unstable APIs.

`denofunc` still requires unstable APIs for unzipping, etc.