### PR TITLE
Fix Windows sometimes not finding func command

### DIFF
--- a/denofunc.ts
+++ b/denofunc.ts
@@ -123,7 +123,7 @@ async function generateFunctions() {
 async function runFunc(...args: string[]) {
     let cmd = ["func", ...args];
     try {
-        console.info(`Starting Azure Functions Core Tools: ${cmd.join(" ")}`);
+        console.info(`Running Azure Functions Core Tools: ${cmd.join(" ")}`);
         const proc = Deno.run({ cmd });
         await proc.status();
     } catch (ex) {
@@ -139,7 +139,7 @@ async function runFunc(...args: string[]) {
             const funcPath = new TextDecoder().decode(rawOutput).split(/\r?\n/).find(p => p.endsWith("func.cmd"));
             if (funcPath) {
                 cmd = [funcPath, ...args];
-                console.info(`Starting Azure Functions Core Tools: ${cmd.join(" ")}`);
+                console.info(`Running Azure Functions Core Tools: ${cmd.join(" ")}`);
                 const proc = Deno.run({ cmd });
                 await proc.status();
             } else {
@@ -152,10 +152,7 @@ async function runFunc(...args: string[]) {
 }
 
 async function publishApp(appName: string) {
-    const cmd = ["func", "azure", "functionapp", "publish", appName, "--no-build", "-b", "local", "--force"];
-    console.info(`Publishing app: ${cmd.join(" ")}`);
-    const proc = Deno.run({ cmd });
-    await proc.status();
+    await runFunc("azure", "functionapp", "publish", appName, "--no-build", "-b", "local", "--force");
 }
 
 function printLogo() {

--- a/denofunc.ts
+++ b/denofunc.ts
@@ -122,9 +122,13 @@ async function generateFunctions() {
 
 async function runFunc(...args: string[]) {
     let cmd = ["func", ...args];
+    const env = {
+        "logging__logLevel__Microsoft": "warning",
+        "logging__logLevel__Worker": "warning"
+    };
     try {
         console.info(`Running Azure Functions Core Tools: ${cmd.join(" ")}`);
-        const proc = Deno.run({ cmd });
+        const proc = Deno.run({ cmd, env });
         await proc.status();
     } catch (ex) {
         if (Deno.build.os === "windows") {
@@ -140,7 +144,7 @@ async function runFunc(...args: string[]) {
             if (funcPath) {
                 cmd = [funcPath, ...args];
                 console.info(`Running Azure Functions Core Tools: ${cmd.join(" ")}`);
-                const proc = Deno.run({ cmd });
+                const proc = Deno.run({ cmd, env });
                 await proc.status();
             } else {
                 throw "Could not located func. Please ensure it is installed and in the path.";

--- a/denofunc.ts
+++ b/denofunc.ts
@@ -121,10 +121,34 @@ async function generateFunctions() {
 }
 
 async function runFunc(...args: string[]) {
-    const cmd = ["func", ...args];
-    console.info(`Starting Azure Functions Core Tools: ${cmd.join(" ")}`);
-    const proc = Deno.run({ cmd });
-    await proc.status();
+    let cmd = ["func", ...args];
+    try {
+        console.info(`Starting Azure Functions Core Tools: ${cmd.join(" ")}`);
+        const proc = Deno.run({ cmd });
+        await proc.status();
+    } catch (ex) {
+        if (Deno.build.os === "windows") {
+            console.info("Could not start func from path, searching for executable...")
+            cmd = ["where.exe", "func"];
+            const proc = Deno.run({
+                cmd,
+                stdout: "piped"
+            });
+            await proc.status();
+            const rawOutput = await proc.output();
+            const funcPath = new TextDecoder().decode(rawOutput).split(/\r?\n/).find(p => p.endsWith("func.cmd"));
+            if (funcPath) {
+                cmd = [funcPath, ...args];
+                console.info(`Starting Azure Functions Core Tools: ${cmd.join(" ")}`);
+                const proc = Deno.run({ cmd });
+                await proc.status();
+            } else {
+                throw "Could not located func. Please ensure it is installed and in the path.";
+            }
+        } else {
+            throw ex;
+        }
+    }
 }
 
 async function publishApp(appName: string) {


### PR DESCRIPTION
Sometimes Deno isn't able to find the func command on Windows. Might have something to do with how func is installed (seems to work when installed by Chocolatey, but not npm).

Added some logic to search for the command if it can't be started from the path. `denofunc start` and `denofunc publish` should now be working on Windows (on the machines I've tested).