### PR TITLE
Bundle cache files for dynamic imported modules

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -6,5 +6,7 @@ export {
   walk,
   readJson,
   writeJson,
+  readFileStr,
+  writeFileStr,
 } from "https://deno.land/std@0.56.0/fs/mod.ts";
 export * from "./worker_deps.ts";


### PR DESCRIPTION
According to this issue https://github.com/denoland/deno/issues/6156, the module files which is imported with variables dynamically are not bundled.

This PR creates cache files in `/PATH/TO/WORK_DIR/.cache` and bundle the cache into package file.

This cache bundling can aoid cold start by this PR https://github.com/anthonychu/azure-functions-deno-template/pull/1, I re-opened.

Please look into this.