### PR TITLE
Support deno v1.3.x

### DIFF
--- a/denofunc.ts
+++ b/denofunc.ts
@@ -306,7 +306,7 @@ async function runWithRetry(
         (p) => p.endsWith(backupCommand),
       );
       if (newPath) {
-        const newCmd = [...runOptions.cmd];
+        const newCmd = [...runOptions.cmd].map(e => e.toString());
         newCmd[0] = newPath;
         const newOptions = { ...runOptions };
         newOptions.cmd = newCmd;


### PR DESCRIPTION
Avoid mismatching type by converting each elements of `RunOption.cwd` to string explicitly.

related to https://github.com/anthonychu/azure-functions-deno-worker/issues/20