### PR TITLE
feature: Deploy an executable

### DIFF
--- a/denofunc.ts
+++ b/denofunc.ts
@@ -6,7 +6,6 @@ import {
   walk,
 } from "./deps.ts";
 
-const shouldBundle = false;
 const baseExecutableFileName = "worker";
 const bundleFileName = "worker.bundle.js";
 const commonDenoOptions = ["--allow-env", "--allow-net", "--allow-read"]
@@ -108,7 +107,6 @@ async function generateExecutable(platformArg?: string) {
     ),
     "worker.ts"
   ];
-  cmd.push("worker.ts");
   console.info(`Running command: ${cmd.join(" ")}`);
   const generateProcess = Deno.run({ cmd });
   await generateProcess.status();

--- a/denofunc.ts
+++ b/denofunc.ts
@@ -195,10 +195,7 @@ async function updateHostJson(platform: string, bundleStyle: string) {
   }
 
   const hostJSON: any = await readJson(hostJsonPath);
-  const executableFileName = bundleStyle === "executable" ? baseExecutableFileName : "deno";
-  hostJSON.customHandler.description.defaultExecutablePath = platform === "windows"
-    ? `D:\\home\\site\\wwwroot\\bin\\${platform}\\${executableFileName}.exe`
-    : `/home/site/wwwroot/bin/${platform}/${executableFileName}`;
+  hostJSON.customHandler.description.defaultExecutablePath = `bin/${platform}/${bundleStyle === "executable" ? baseExecutableFileName : "deno"}${platform === "windows" ? ".exe" : ""}`;
   hostJSON.customHandler.description.arguments = bundleStyle === "executable" ? [] : [
     "run",
     ...commonDenoOptions,

--- a/denofunc.ts
+++ b/denofunc.ts
@@ -421,9 +421,10 @@ denofunc start
 denofunc publish <function_app_name> [options]
     Publish to Azure
     options:
-      --slot <slot_name>                       Specify name of the deployment slot
-      --bundle-style executable|jsbundle|none  
-        executable(default): Deploy worker as one executable
-        jsbundle:
+      --slot         <slot_name>              Specify name of the deployment slot
+      --bundle-style executable|jsbundle|none Select bundle style on deployment 
+        executable(default): Bundle as one executable
+        jsbundle:            Bundle as one javascript worker & Deno runtime
+        none:                No bundle
     `);
 }

--- a/denofunc.ts
+++ b/denofunc.ts
@@ -69,15 +69,14 @@ async function listFiles(dir: string) {
 }
 
 async function generateExecutable(platform?: string) {
-  const entries = ['', `.exe`].map(ext => `./${baseExecutableFileName}${ext}`);
-  for (const entry of entries) {
-    if (await fileExists(entry)) await Deno.remove(entry);
-  }
+  try {
+    await Deno.remove('./bin', {recursive: true});
+  } catch {}
+  await Deno.mkdir(`./bin/${platform}`, { recursive: true });
 
-  const cmd = ["deno", "compile", "--unstable", "--lite", "--allow-env", "--allow-net", "--allow-read", "--output", baseExecutableFileName];
+  const cmd = ["deno", "compile", "--unstable", "--lite", "--allow-env", "--allow-net", "--allow-read", "--output", `./bin/${platform}/${baseExecutableFileName}`];
   if (platform && ['windows', 'linux'].includes(platform)) {
-    cmd.push('--target');
-    cmd.push(platform === 'windows' ? 'x86_64-pc-windows-msvc' : 'x86_64-unknown-linux-gnu');
+    cmd.push('--target', platform === 'windows' ? 'x86_64-pc-windows-msvc' : 'x86_64-unknown-linux-gnu');
   }
   cmd.push("worker.ts");
   console.info(`Running command: ${cmd.join(" ")}`);
@@ -180,8 +179,8 @@ async function updateHostJson(platform: string) {
 
   const hostJSON: any = await readJson(hostJsonPath);
   hostJSON.customHandler.description.defaultExecutablePath = platform === "windows"
-    ? `D:\\home\\site\\wwwroot\\${baseExecutableFileName}.exe`
-    : `/home/site/wwwroot/${baseExecutableFileName}`;
+    ? `D:\\home\\site\\wwwroot\\bin\\${platform}\\${baseExecutableFileName}.exe`
+    : `/home/site/wwwroot/bin/${platform}/${baseExecutableFileName}`;
   await writeJson(hostJsonPath, hostJSON); // returns a promise
 }
 


### PR DESCRIPTION
This PR includes generating a single executable binary by `deno compile` and deploying the executable binary when executing `denofunc publish`.
Tested on deno v1.7.5