### PR TITLE
fix: handling `context.res` object between worker and host

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -135,6 +135,11 @@ export class AzureFunctionsWorker {
 
           const result = await Promise.resolve(registration.handler(context));
 
+          // Merge `context.res` into `context.bindings`
+          // `context.res` is the special property for HTTP response
+          // https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=v2#response-object
+          if (context.res) context.bindings.res = context.res;
+
           ctx.response.body = {
             Logs: context.log.logs,
             Outputs: context.bindings,


### PR DESCRIPTION
Merge `context.res` into `context.bindings`